### PR TITLE
B Fix parenthesis error in first example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ ApprovalTests allows for easy testing of larger objects, strings and anything el
 
 ```go
 func TestHelloWorld(t *testing.T) {
-	approvals.VerifyString(t, "Hello World!"))
+	approvals.VerifyString(t, "Hello World!")
 }
 ```
 


### PR DESCRIPTION
I noticed, by copy-paste, that the first code example did not run at all.

## Description

Just a fix for a documentation error, one parenthesis too much in front page first example.

## The solution

Remove superfluous ) parenthesis.
 
## Notation

