### PR TITLE
Add support for linux to some reporters

### DIFF
--- a/reporters/beyond_compare.go
+++ b/reporters/beyond_compare.go
@@ -19,6 +19,8 @@ func (s *beyondCompare) Report(approved, received string) bool {
 		programName = "C:/Program Files/Beyond Compare 4/BComp.exe"
 	case goosDarwin:
 		programName = "/Applications/Beyond Compare.app/Contents/MacOS/bcomp"
+	case goosLinux:
+		programName = "/usr/bin/bcompare"
 	}
 
 	return launchProgram(programName, approved, xs...)

--- a/reporters/constants.go
+++ b/reporters/constants.go
@@ -3,4 +3,5 @@ package reporters
 const (
 	goosWindows = "windows"
 	goosDarwin  = "darwin"
+	goosLinux   = "linux"
 )

--- a/reporters/file_launcher.go
+++ b/reporters/file_launcher.go
@@ -18,6 +18,8 @@ func (s *fileLauncher) Report(approved, received string) bool {
 	switch runtime.GOOS {
 	case goosWindows:
 		cmd = exec.Command("cmd", "/C", "start", "Needed Title", received, "/B")
+	case goosLinux:
+		return false
 	default:
 		cmd = exec.Command("open", received)
 	}

--- a/reporters/goland.go
+++ b/reporters/goland.go
@@ -17,6 +17,8 @@ func (s *goland) Report(approved, received string) bool {
 		programName = "unknown"
 	case goosDarwin:
 		programName = "/Applications/GoLand.app/Contents/MacOS/goland"
+	case goosLinux:
+		programName = "/usr/local/bin/goland"
 	}
 
 	return launchProgram(programName, approved, xs...)

--- a/reporters/intellij.go
+++ b/reporters/intellij.go
@@ -18,6 +18,8 @@ func (s *intellij) Report(approved, received string) bool {
 		programName = "C:/Program Files (x86)/JetBrains/IntelliJ IDEA 2016/bin/idea.exe"
 	case goosDarwin:
 		programName = "/Applications/IntelliJ IDEA.app/Contents/MacOS/idea"
+	case goosLinux:
+		programName = "/usr/local/bin/idea"
 	}
 
 	return launchProgram(programName, approved, xs...)

--- a/reporters/vscode.go
+++ b/reporters/vscode.go
@@ -23,6 +23,8 @@ func (s *vsCode) Report(approved, received string) bool {
 		}
 	case goosDarwin:
 		programName = "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code"
+	case goosLinux:
+		programName = "/usr/bin/code"
 	}
 
 	return launchProgram(programName, approved, xs...)


### PR DESCRIPTION
## Description

Adds linux support to some reporters: goland, intellij, beyondcompare.

## The solution

Just added the executable paths that are used on fedora linux. 

Comes without tests as I can't find any tests for the actual reporter implementations.


