### PR TITLE
Fix tabs to fix godoc generation

### DIFF
--- a/approvals.go
+++ b/approvals.go
@@ -170,12 +170,12 @@ func (s *frontLoadedReporterCloser) Close() error {
 // in a package directory through go's setup feature.
 //
 //
-// func TestMain(m *testing.M) {
-// 	    r := approvals.UseReporter(reporters.NewBeyondCompareReporter())
-//      defer r.Close()
+//	func TestMain(m *testing.M) {
+//		r := approvals.UseReporter(reporters.NewBeyondCompareReporter())
+//		defer r.Close()
 //
-//      os.Exit(m.Run())
-// }
+//		os.Exit(m.Run())
+//	}
 //
 func UseReporter(reporter reporters.Reporter) io.Closer {
 	closer := &reporterCloser{
@@ -187,7 +187,7 @@ func UseReporter(reporter reporters.Reporter) io.Closer {
 }
 
 // UseFrontLoadedReporter configures reporters ahead of all other reporters to
-// handle situations like CI.  These reporters usually prevent reporting in
+// handle situations like CI. These reporters usually prevent reporting in
 // scenarios that are headless.
 func UseFrontLoadedReporter(reporter reporters.Reporter) io.Closer {
 	closer := &frontLoadedReporterCloser{
@@ -212,11 +212,11 @@ func getReporter() reporters.Reporter {
 // for all of your test cases in a package directory.
 //
 //
-// func TestMain(m *testing.M) {
-//     approvals.UseFolder("testdata")
+//	func TestMain(m *testing.M) {
+//		approvals.UseFolder("testdata")
 //
-//     os.Exit(m.Run())
-// }
+//		os.Exit(m.Run())
+//	}
 //
 func UseFolder(f string) {
 	defaultFolder = f

--- a/examples_test.go
+++ b/examples_test.go
@@ -58,7 +58,7 @@ func ExampleVerifyAllCombinationsFor2_withSkip() {
 	approvals.VerifyAllCombinationsFor2(t, "combineWords", functionToTest, words, otherWords)
 	printFileContent("examples_test.ExampleVerifyAllCombinationsFor2_withSkip.received.txt")
 	// Output:
-	// 	This produced the file examples_test.ExampleVerifyAllCombinationsFor2_withSkip.received.txt
+	// This produced the file examples_test.ExampleVerifyAllCombinationsFor2_withSkip.received.txt
 	// It will be compared against the examples_test.ExampleVerifyAllCombinationsFor2_withSkip.approved.txt file
 	// and contains the text:
 	//


### PR DESCRIPTION
My previous commits messed up the godoc generation (I had forgotten it  was generated directly from the comments and that it was relying on indentation).

Verified on https://bradleyjkemp.dev/godoc-playground/
