### PR TITLE
Add reporter based on the command line `diff` tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.so
 
 .idea/
+*.iml
 
 # Folders
 _obj

--- a/approvals.go
+++ b/approvals.go
@@ -28,11 +28,13 @@ type Failable interface {
 	Name() string
 	Log(args ...interface{})
 	Logf(format string, args ...interface{})
+	Helper()
 }
 
 // VerifyWithExtension Example:
 //   VerifyWithExtension(t, strings.NewReader("Hello"), ".txt")
 func VerifyWithExtension(t Failable, reader io.Reader, extWithDot string) {
+	t.Helper()
 	namer := getApprovalName(t)
 
 	reporter := getReporter()
@@ -49,12 +51,14 @@ func VerifyWithExtension(t Failable, reader io.Reader, extWithDot string) {
 // Verify Example:
 //   Verify(t, strings.NewReader("Hello"))
 func Verify(t Failable, reader io.Reader) {
+	t.Helper()
 	VerifyWithExtension(t, reader, ".txt")
 }
 
 // VerifyString stores the passed string into the received file and confirms
 // that it matches the approved local file. On failure, it will launch a reporter.
 func VerifyString(t Failable, s string) {
+	t.Helper()
 	reader := strings.NewReader(s)
 	Verify(t, reader)
 }
@@ -62,6 +66,7 @@ func VerifyString(t Failable, s string) {
 // VerifyXMLStruct Example:
 //   VerifyXMLStruct(t, xml)
 func VerifyXMLStruct(t Failable, obj interface{}) {
+	t.Helper()
 	xmlContent, err := xml.MarshalIndent(obj, "", "  ")
 	if err != nil {
 		tip := ""
@@ -78,6 +83,7 @@ func VerifyXMLStruct(t Failable, obj interface{}) {
 // VerifyXMLBytes Example:
 //   VerifyXMLBytes(t, []byte("<Test/>"))
 func VerifyXMLBytes(t Failable, bs []byte) {
+	t.Helper()
 	type node struct {
 		Attr     []xml.Attr
 		XMLName  xml.Name
@@ -98,6 +104,7 @@ func VerifyXMLBytes(t Failable, bs []byte) {
 // VerifyJSONStruct Example:
 //   VerifyJSONStruct(t, json)
 func VerifyJSONStruct(t Failable, obj interface{}) {
+	t.Helper()
 	jsonb, err := json.MarshalIndent(obj, "", "  ")
 	if err != nil {
 		message := fmt.Sprintf("error while pretty printing JSON\nerror:\n  %s\nJSON:\n  %s\n", err, obj)
@@ -110,6 +117,7 @@ func VerifyJSONStruct(t Failable, obj interface{}) {
 // VerifyJSONBytes Example:
 //   VerifyJSONBytes(t, []byte("{ \"Greeting\": \"Hello\" }"))
 func VerifyJSONBytes(t Failable, bs []byte) {
+	t.Helper()
 	var obj map[string]interface{}
 	err := json.Unmarshal(bs, &obj)
 	if err != nil {
@@ -123,6 +131,7 @@ func VerifyJSONBytes(t Failable, bs []byte) {
 // VerifyMap Example:
 //   VerifyMap(t, map[string][string] { "dog": "bark" })
 func VerifyMap(t Failable, m interface{}) {
+	t.Helper()
 	outputText := utils.PrintMap(m)
 	VerifyString(t, outputText)
 }
@@ -130,6 +139,7 @@ func VerifyMap(t Failable, m interface{}) {
 // VerifyArray Example:
 //   VerifyArray(t, []string{"dog", "cat"})
 func VerifyArray(t Failable, array interface{}) {
+	t.Helper()
 	outputText := utils.PrintArray(array)
 	VerifyString(t, outputText)
 }
@@ -137,6 +147,7 @@ func VerifyArray(t Failable, array interface{}) {
 // VerifyAll Example:
 //   VerifyAll(t, "uppercase", []string("dog", "cat"}, func(x interface{}) string { return strings.ToUpper(x.(string)) })
 func VerifyAll(t Failable, header string, collection interface{}, transform func(interface{}) string) {
+	t.Helper()
 	if len(header) != 0 {
 		header = fmt.Sprintf("%s\n\n\n", header)
 	}

--- a/approvals.go
+++ b/approvals.go
@@ -157,7 +157,7 @@ func VerifyAll(t Failable, header string, collection interface{}, transform func
 }
 
 type reporterCloser struct {
-	reporter *reporters.Reporter
+	reporter reporters.Reporter
 }
 
 func (s *reporterCloser) Close() error {
@@ -166,7 +166,7 @@ func (s *reporterCloser) Close() error {
 }
 
 type frontLoadedReporterCloser struct {
-	reporter *reporters.Reporter
+	reporter reporters.Reporter
 }
 
 func (s *frontLoadedReporterCloser) Close() error {
@@ -193,7 +193,7 @@ func UseReporter(reporter reporters.Reporter) io.Closer {
 		reporter: defaultReporter,
 	}
 
-	defaultReporter = &reporter
+	defaultReporter = reporter
 	return closer
 }
 
@@ -205,14 +205,14 @@ func UseFrontLoadedReporter(reporter reporters.Reporter) io.Closer {
 		reporter: defaultFrontLoadedReporter,
 	}
 
-	defaultFrontLoadedReporter = &reporter
+	defaultFrontLoadedReporter = reporter
 	return closer
 }
 
 func getReporter() reporters.Reporter {
 	return reporters.NewFirstWorkingReporter(
-		*defaultFrontLoadedReporter,
-		*defaultReporter,
+		defaultFrontLoadedReporter,
+		defaultReporter,
 	)
 }
 

--- a/reporter_test.go
+++ b/reporter_test.go
@@ -21,6 +21,7 @@ func (s *TestFailable) Fatalf(format string, args ...interface{}) {}
 func (s *TestFailable) Fatal(args ...interface{})                 {}
 func (s *TestFailable) Log(args ...interface{})                   {}
 func (s *TestFailable) Logf(format string, args ...interface{})   {}
+func (s *TestFailable) Helper()                                   {}
 
 type testReporter struct {
 	called    bool

--- a/reporters/diff_reporter.go
+++ b/reporters/diff_reporter.go
@@ -15,7 +15,7 @@ func NewFrontLoadedReporter() Reporter {
 
 // NewDiffReporter creates the default diff reporter.
 func NewDiffReporter() Reporter {
-	tmp := NewFirstWorkingReporter(
+	return NewFirstWorkingReporter(
 		NewBeyondCompareReporter(),
 		NewIntelliJReporter(),
 		NewFileMergeReporter(),
@@ -24,8 +24,6 @@ func NewDiffReporter() Reporter {
 		NewPrintSupportedDiffProgramsReporter(),
 		NewQuietReporter(),
 	)
-
-	return tmp
 }
 
 func launchProgram(programName, approved string, args ...string) bool {

--- a/reporters/diff_reporter.go
+++ b/reporters/diff_reporter.go
@@ -7,16 +7,16 @@ import (
 )
 
 // NewFrontLoadedReporter creates the default front loaded reporter.
-func NewFrontLoadedReporter() *Reporter {
+func NewFrontLoadedReporter() Reporter {
 	tmp := NewFirstWorkingReporter(
 		NewContinuousIntegrationReporter(),
 	)
 
-	return &tmp
+	return tmp
 }
 
 // NewDiffReporter creates the default diff reporter.
-func NewDiffReporter() *Reporter {
+func NewDiffReporter() Reporter {
 	tmp := NewFirstWorkingReporter(
 		NewBeyondCompareReporter(),
 		NewIntelliJReporter(),
@@ -27,7 +27,7 @@ func NewDiffReporter() *Reporter {
 		NewQuietReporter(),
 	)
 
-	return &tmp
+	return tmp
 }
 
 func launchProgram(programName, approved string, args ...string) bool {

--- a/reporters/diff_reporter.go
+++ b/reporters/diff_reporter.go
@@ -8,11 +8,9 @@ import (
 
 // NewFrontLoadedReporter creates the default front loaded reporter.
 func NewFrontLoadedReporter() Reporter {
-	tmp := NewFirstWorkingReporter(
+	return NewFirstWorkingReporter(
 		NewContinuousIntegrationReporter(),
 	)
-
-	return tmp
 }
 
 // NewDiffReporter creates the default diff reporter.

--- a/reporters/diff_reporter.go
+++ b/reporters/diff_reporter.go
@@ -21,6 +21,7 @@ func NewDiffReporter() Reporter {
 		NewFileMergeReporter(),
 		NewVSCodeReporter(),
 		NewGoLandReporter(),
+		NewRealDiffReporter(),
 		NewPrintSupportedDiffProgramsReporter(),
 		NewQuietReporter(),
 	)

--- a/reporters/real_diff_reporter.go
+++ b/reporters/real_diff_reporter.go
@@ -1,0 +1,23 @@
+package reporters
+
+import (
+	"github.com/approvals/go-approval-tests/utils"
+	"os"
+	"os/exec"
+)
+
+type realDiff struct{}
+
+func NewRealDiffReporter() Reporter {
+	return &realDiff{}
+}
+
+func (*realDiff) Report(approved, received string) bool {
+	utils.EnsureExists(approved)
+
+	cmd := exec.Command("diff", "-u", approved, received)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Run()
+	return true
+}


### PR DESCRIPTION
On behalf of my employer, Maersk, I am contributing this PR which consists of three changes:

1. A reporter that prints the diff using the command line `diff` tool. The implementation is straight forwardly adapted from the other reporters. I believe adding this reporter will fix issue #27 in many cases given that Linux servers are likely to have some version of `diff` installed.
2. Adding a call to t.Helper in the verify functions, so that when approval tests fail, the stacktrace will point to the call of the verify function instead of to some line within the library. This makes it easier for the user of the library to understand which assertion in their tests failed.
3. Changing some pointers to interface values to plain interface values. It is unnecessary and unidiomatic to have pointers to interfaces in Go. Interfaces are already pointers internally. This should not affect any behavior.

Looking forward to your feedback.

Thanks,
Christoffer G. Thomsen
Senior Software Engineer
Maersk