### PR TITLE
Initial JSONPath scrubber 

### DIFF
--- a/approvals.go
+++ b/approvals.go
@@ -286,6 +286,15 @@ func (v verifyOptions) WithRegexScrubber(scrubber *regexp.Regexp, replacer strin
 	return v
 }
 
+// WithJSONPathScrubber allows you to 'scrub' dynamic data such as timestamps within your test input
+// and replace it with a static placeholder
+func (v verifyOptions) WithJSONPathScrubber(path string, replacer string) verifyOptions {
+	v.scrubbers = append(v.scrubbers, func(s string) string {
+		return scrubJSONPath(s, path, replacer)
+	})
+	return v
+}
+
 // WithExtension overrides the default file extension (.txt) for approval files.
 func (v verifyOptions) WithExtension(extension string) verifyOptions {
 	v.extWithDot = extension

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/approvals/go-approval-tests
 
 go 1.12
+
+require github.com/bitly/go-simplejson v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/bitly/go-simplejson v0.5.0 h1:6IH+V8/tVMab511d5bn4M7EwGXZf9Hj6i2xSwkNEM+Y=
+github.com/bitly/go-simplejson v0.5.0/go.mod h1:cXHtHw4XUPsvGaxgjIAn8PhEWG9NfngEKAMDJEczWVA=

--- a/scrubber_json_path.go
+++ b/scrubber_json_path.go
@@ -1,0 +1,71 @@
+package approvals
+
+import (
+	"strings"
+
+	"github.com/bitly/go-simplejson"
+)
+
+// converts received JSON string into a simpleJSON struct, scrubs the path with passed "scrubVal" using a separate util function, turns it into a string again
+// (pretty naive implementation)
+func scrubJSONPath(jsonStr string, path string, scrubVal interface{}) string {
+	js, err := simplejson.NewJson([]byte(jsonStr))
+	if err != nil {
+		panic(err)
+	}
+
+	scrubJSONPathSimpleJSON(js, path, scrubVal)
+
+	resS, err := js.EncodePretty()
+	if err != nil {
+		panic(err)
+	}
+	return string(resS)
+}
+
+// limited implementation of JSONPath for scrubbing values in simplejson structs:
+//
+// ScrubJSONPath(data, "foo.bar", "<bar_scrubbed>")
+// { foo: { bar: "123" } }                   -> { foo: { bar: "<bar_scrubbed>" }
+//
+// - ScrubJSONPath(data, "foo[*].bar", "<bar_arr_scrubbed>")
+// { foo: [{ bar: "123" }, { bar: "234" }] } -> { foo: [{ bar: "<bar_arr_scrubbed>" }, { bar: "<bar_arr_scrubbed>" }]) }
+func scrubJSONPathSimpleJSON(data *simplejson.Json, path string, scrubVal interface{}) {
+	// "foo[*].bar" -> ["foo", "[*]", "bar"]
+	var elems []string
+	for _, elDot := range strings.Split(path, ".") {
+		if elDot == "[*]" {
+			elems = append(elems, "[*]")
+		} else if strings.HasSuffix(elDot, "[*]") {
+			elems = append(elems, strings.TrimSuffix(elDot, "[*]"))
+			elems = append(elems, "[*]")
+		} else {
+			elems = append(elems, elDot)
+		}
+	}
+
+	// end of recursive iteration, set the value (if key is present) and return:
+	if len(elems) == 1 {
+		if _, found := data.CheckGet(elems[0]); found {
+			data.Set(elems[0], scrubVal)
+		}
+		return
+	}
+
+	leftPath := path
+	for _, el := range elems {
+		leftPath = strings.TrimPrefix(leftPath, el)
+		leftPath = strings.TrimPrefix(leftPath, ".")
+
+		kjkj // special key for array object keys:
+		if el == "[*]" {
+			for i := 0; i < len(data.MustArray()); i++ {
+				scrubJSONPathSimpleJSON(data.GetIndex(i), leftPath, scrubVal)
+			}
+		} else {
+			if _, found := data.CheckGet(el); found {
+				scrubJSONPathSimpleJSON(data.Get(el), leftPath, scrubVal)
+			}
+		}
+	}
+}

--- a/scrubber_test.go
+++ b/scrubber_test.go
@@ -86,3 +86,17 @@ func TestVerifyAllWithRegexScrubber(t *testing.T) {
 	xs := []string{"Christopher", "Llewellyn"}
 	approvals.VerifyAll(t, "uppercase", xs, func(x interface{}) string { return fmt.Sprintf("%s => %s", x, strings.ToUpper(x.(string))) }, opts)
 }
+
+func TestVerifyJSONBytesWithJSONPathScrubber(t *testing.T) {
+	opts := approvals.Options().
+		WithJSONPathScrubber("greeting", "Hi!!!!").
+		WithJSONPathScrubber("list[*].greeting", "Why hello!!!")
+
+	jb := []byte(`{
+		"greeting":"Hello",
+		"list":[
+			{ "greeting": "Hello 1" },
+			{ "greeting": "Hello 2"}]
+		}`)
+	approvals.VerifyJSONBytes(t, jb, opts)
+}

--- a/testdata/scrubber_test.TestVerifyJSONBytesWithJSONPathScrubber.approved.json
+++ b/testdata/scrubber_test.TestVerifyJSONBytesWithJSONPathScrubber.approved.json
@@ -1,0 +1,11 @@
+{
+  "greeting": "Hi!!!!",
+  "list": [
+    {
+      "greeting": "Why hello!!!"
+    },
+    {
+      "greeting": "Why hello!!!"
+    }
+  ]
+}


### PR DESCRIPTION
A proof-of-concept PR implementing https://github.com/approvals/go-approval-tests/issues/38 .

Ignore the implementation details for now, focus on the public API.

If it looks right then we can work on it! (I'll also happily rebase commits to fit the preferred notation.)

## Description

Adds basic support for scrubbing values by passed JSONPath. To be used with `approvals.VerifyJsonStruct(...)` and `approvals.VerifyJSONBytes(...)`.

Usage examples:
```go
opts := approvals.Options().WithJSONPathScrubber("id", "<scrubbed_id>")

jb := []byte(`{ "id": 1 }`)
approvals.VerifyJSONBytes(t, jb, opts)
```

Also works for scrubbing properties in lists of objects:
```go
 opts := approvals.Options().WithJSONPathScrubber("items[*].id", "<scrubbed_id>")

jb := []byte(`{ "items": [{ "id": 1 }, { "id": 2 }] }`)
approvals.VerifyJSONBytes(t, jb, opts)
```

## The solution

What happens during scrubbing:

1. The JSON string is un-marshalled into a https://pkg.go.dev/github.com/bitly/go-simplejson struct.
2. A recursive function scrubs values based on the passed path.
3. Resulting simplejson struct is marshalled back into a pretty-printed JSON.

What's nice: it works and should be good great for most common usage:
1. Scrubbing object properties.
2. Scrubbing properties in lists of objects.

The things left to iterate on (in this PR or later):
1. Would be nice to drop `simplejson` dependency.
2. Doesn't look optimal perf-wise to pass JSON string to a scrubber instead of the original map.
3. Doesn't implement full JSONPath proposal.
