### PR TITLE
verifyOptions.WithCustomScrubber: ability to pass a custom scrubber func

### DIFF
--- a/approvals.go
+++ b/approvals.go
@@ -286,6 +286,15 @@ func (v verifyOptions) WithRegexScrubber(scrubber *regexp.Regexp, replacer strin
 	return v
 }
 
+// WithCustomScrubber allows you to 'scrub' dynamic data such as timestamps within your test input
+// using a custom function and replace it with a static placeholder
+func (v verifyOptions) WithCustomScrubber(scrubFunc func(s, r string) string, replacer string) verifyOptions {
+	v.scrubbers = append(v.scrubbers, func(s string) string {
+		return scrubFunc(s, replacer)
+	})
+	return v
+}
+
 // WithExtension overrides the default file extension (.txt) for approval files.
 func (v verifyOptions) WithExtension(extension string) verifyOptions {
 	v.extWithDot = extension

--- a/scrubber_test.go
+++ b/scrubber_test.go
@@ -86,3 +86,14 @@ func TestVerifyAllWithRegexScrubber(t *testing.T) {
 	xs := []string{"Christopher", "Llewellyn"}
 	approvals.VerifyAll(t, "uppercase", xs, func(x interface{}) string { return fmt.Sprintf("%s => %s", x, strings.ToUpper(x.(string))) }, opts)
 }
+
+func scrubFunc(s, replacer string) string {
+	return regexp.MustCompile("Hello").ReplaceAllString(s, replacer)
+}
+
+func TestVerifyJSONBytesWithCustomScrubber(t *testing.T) {
+	opts := approvals.Options().WithCustomScrubber(scrubFunc, "Hi")
+
+	jb := []byte("{ \"Greeting\": \"Hello\" }")
+	approvals.VerifyJSONBytes(t, jb, opts)
+}


### PR DESCRIPTION
A proof-of-concept PR implementing ability to pass a custom scrubbing function.

It received the verified string and a `replacer`, returns a scrubbed verified string.

Seems like a legit shortcut to make scrubbing API much more flexible. Got this idea when working on https://github.com/approvals/go-approval-tests/pull/42 .

I'd appreciate a check on the public API more than anything, and if the idea seems valid overall. Then we can work out the details (+ things like the preferred commit notation/format).

## Description

Usage examples:
```go
// replaces "Hello" with the replacer string:
func scrubFunc(s, replacer string) string {
	return regexp.MustCompile("Hello").ReplaceAllString(s, replacer)
}

func TestVerifyJSONBytesWithCustomScrubber(t *testing.T) {
	opts := approvals.Options().WithCustomScrubber(scrubFunc, "Hi")

	jb := []byte("{ \"Greeting\": \"Hello\" }")
	approvals.VerifyJSONBytes(t, jb, opts)
}
```