### PR TITLE
Sanitize non-ASCII characters in approval file names

### DIFF
--- a/sanitize.go
+++ b/sanitize.go
@@ -3,6 +3,7 @@ package approvals
 import (
 	"path/filepath"
 	"strings"
+	"unicode"
 )
 
 type FileNameSanitizer func(string) string
@@ -10,6 +11,13 @@ type FileNameSanitizer func(string) string
 var CurrentFileNameSanitizer FileNameSanitizer = DefaultSanitizeFileName
 
 func isForbiddenFileNameChar(c rune) bool {
+	// Normalize any non-ASCII rune. Em-dashes, smart quotes and accented
+	// letters — increasingly common in AI-authored test names — produce file
+	// paths that `go mod zip` rejects ("malformed file path: invalid char"),
+	// which breaks `go get` for any module that ships such approval fixtures.
+	if c > unicode.MaxASCII {
+		return true
+	}
 	return strings.ContainsRune(`,;:/?"<>|' {}()[]\`, c)
 }
 

--- a/sanitize_test.go
+++ b/sanitize_test.go
@@ -1,13 +1,29 @@
 package approvals_test
 
 import (
+	"path/filepath"
 	"testing"
 
 	approvals "github.com/approvals/go-approval-tests"
 )
 
 func TestDefaultSanitizeFileName(t *testing.T) {
-	approvals.DefaultSanitizeFileName("testdata/approvals_test.{foo}.approved.txt")
+	// Inputs/expectations use forward slashes; expectations are run through
+	// filepath.FromSlash so the comparison holds on Windows too (the function
+	// rejoins via filepath.Join, which uses the OS separator).
+	cases := map[string]string{
+		// forbidden ASCII characters are replaced with '_'
+		"testdata/approvals_test.{foo}.approved.txt": "testdata/approvals_test._foo_.approved.txt",
+		"testdata/has space (and parens).txt":        "testdata/has_space__and_parens_.txt",
+		// allowed ASCII (hyphen, dot, @, alphanumerics) is preserved
+		"testdata/ok-name.v1@test.com.approved.txt": "testdata/ok-name.v1@test.com.approved.txt",
+	}
+
+	for in, want := range cases {
+		if got := approvals.DefaultSanitizeFileName(in); got != filepath.FromSlash(want) {
+			t.Errorf("DefaultSanitizeFileName(%q) = %q, want %q", in, got, filepath.FromSlash(want))
+		}
+	}
 }
 
 func TestDefaultSanitizeFileNameNonASCII(t *testing.T) {
@@ -23,8 +39,8 @@ func TestDefaultSanitizeFileNameNonASCII(t *testing.T) {
 	}
 
 	for in, want := range cases {
-		if got := approvals.DefaultSanitizeFileName(in); got != want {
-			t.Errorf("DefaultSanitizeFileName(%q) = %q, want %q", in, got, want)
+		if got := approvals.DefaultSanitizeFileName(in); got != filepath.FromSlash(want) {
+			t.Errorf("DefaultSanitizeFileName(%q) = %q, want %q", in, got, filepath.FromSlash(want))
 		}
 	}
 }

--- a/sanitize_test.go
+++ b/sanitize_test.go
@@ -9,3 +9,22 @@ import (
 func TestDefaultSanitizeFileName(t *testing.T) {
 	approvals.DefaultSanitizeFileName("testdata/approvals_test.{foo}.approved.txt")
 }
+
+func TestDefaultSanitizeFileNameNonASCII(t *testing.T) {
+	cases := map[string]string{
+		// em-dash + surrounding spaces (a common AI-authored subtest name)
+		"testdata/render.shorten enabled — body.approved.txt": "testdata/render.shorten_enabled___body.approved.txt",
+		// accented letter
+		"testdata/email.héctor@test.com.approved.txt": "testdata/email.h_ctor@test.com.approved.txt",
+		// smart quotes
+		"testdata/quote.“smart”.approved.txt": "testdata/quote._smart_.approved.txt",
+		// plain ASCII is preserved unchanged (hyphen, dot, @ are allowed)
+		"testdata/ok-name.v1@test.com.approved.txt": "testdata/ok-name.v1@test.com.approved.txt",
+	}
+
+	for in, want := range cases {
+		if got := approvals.DefaultSanitizeFileName(in); got != want {
+			t.Errorf("DefaultSanitizeFileName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

`DefaultSanitizeFileName` only replaces a fixed set of **ASCII** characters:

```go
func isForbiddenFileNameChar(c rune) bool {
	return strings.ContainsRune(`,;:/?"<>|' {}()[]\`, c)
}
```

Non-ASCII runes pass straight through into the approved/received file names. So a subtest named, say, `shorten enabled — body is shortened` (em-dash) or one parameterized by `héctor@test.com` produces a fixture file whose path contains those bytes.

Go's module packaging rejects non-ASCII file paths, so any module that ships such fixtures can no longer be fetched:

```
go: github.com/…@latest: create zip: …/render_test.…shorten_enabled_—_body_is_shortened.approved.json: malformed file path "…": invalid char '—'
```

This is increasingly common as AI-authored test names use em-dashes, smart quotes (`“ ” ‘ ’`) and ellipses (`…`).

## Fix

Treat any rune outside ASCII as forbidden, so it is normalized to `_` exactly like the existing path-hostile characters:

```go
func isForbiddenFileNameChar(c rune) bool {
	if c > unicode.MaxASCII {
		return true
	}
	return strings.ContainsRune(`,;:/?"<>|' {}()[]\`, c)
}
```

Allowed ASCII (`-`, `.`, `@`, alphanumerics) is unchanged; only non-ASCII and the already-forbidden set become `_`.

## Tests

Added `TestDefaultSanitizeFileNameNonASCII` covering em-dash, accented letters, smart quotes, and an ASCII-preserved case. Full suite green (`go test ./...`).

## Summary by Sourcery

Sanitize approval file names by treating all non-ASCII runes as forbidden and normalizing them, and add coverage for the new behavior.

Bug Fixes:
- Prevent generation of approval fixture file paths containing non-ASCII characters that break Go module packaging.

Tests:
- Add table-driven tests verifying that non-ASCII characters in approval file names are normalized while allowed ASCII characters are preserved.